### PR TITLE
 Make inline javascript compatible with CSP 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,8 @@
 {
-  "name": "echo511/plupload",
+  "name": "irkallacz/plupload",
   "type": "library",
   "description": "Plupload component for Nette Framework.",
-  "keywords": [
-    "echo511",
+  "keywords": 
     "nette",
     "plupload"
   ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "irkallacz/plupload",
   "type": "library",
   "description": "Plupload component for Nette Framework.",
-  "keywords": 
+  "keywords": [ 
     "nette",
     "plupload"
   ],

--- a/src/Echo511/Plupload/DI/PluploadExtension.php
+++ b/src/Echo511/Plupload/DI/PluploadExtension.php
@@ -21,10 +21,8 @@ class PluploadExtension extends CompilerExtension
 	 */
 	public function loadConfiguration()
 	{
-		$builder = $this->getContainerBuilder();
 		$config = $this->loadFromFile(__DIR__ . '/../config/plupload.neon');
-		$namespace = 'Echo511.Plupload.DI';
-		$this->compiler->parseServices($builder, $config, $namespace);
+		$this->compiler->loadDefinitionsFromConfig($config['services']);
 	}
 
 

--- a/src/Echo511/Plupload/config/plupload.neon
+++ b/src/Echo511/Plupload/config/plupload.neon
@@ -1,19 +1,19 @@
 services:    
     control:
-        class: Echo511\Plupload\Control\PluploadControl
+        factory: Echo511\Plupload\Control\PluploadControl
         implement: Echo511\Plupload\Control\IPluploadControlFactory
 
     uploader:
-        class: Echo511\Plupload\Service\Uploader(%tempDir%/echo511.plupload)
+        factory: Echo511\Plupload\Service\Uploader(%tempDir%/echo511.plupload)
 
     uploadQueue:
-        class: Echo511\Plupload\Entity\UploadQueue
+        factory: Echo511\Plupload\Entity\UploadQueue
         implement: Echo511\Plupload\Entity\IUploadQueueFactory
         parameters: [id]
         arguments: [%id%]
 
     upload:
-        class: Echo511\Plupload\Entity\Upload
+        factory: Echo511\Plupload\Entity\Upload
         implement: Echo511\Plupload\Entity\IUploadFactory
         parameters: [filename, name]
         arguments: [%filename%, %name%]

--- a/src/Echo511/Plupload/templates/control/plupload.latte
+++ b/src/Echo511/Plupload/templates/control/plupload.latte
@@ -2,7 +2,7 @@
     <p>Your browser doesn't have Flash, Silverlight or HTML5 support.</p>
 </div>
 
-<script type="text/javascript">	
+<script type="text/javascript" n:nonce>	
 $(function() {
     $("#{$id|noescape}uploader").plupload({
         runtimes : 'html5',


### PR DESCRIPTION
n:nonce macro is important when CSP is used and only way that direct JS is gonna work, is with nonce attribute (witch macro provide). 

If CSP is not on, it doesn't do anything, so it is no big deal to implement.   